### PR TITLE
Fix argv[0] path handling in app_code

### DIFF
--- a/app_bootloader/Makefile
+++ b/app_bootloader/Makefile
@@ -15,8 +15,8 @@ CC = arm-none-eabi-gcc
 LINK = arm-none-eabi-ld
 AS = arm-none-eabi-as
 OBJCOPY = arm-none-eabi-objcopy
-CFLAGS += -Wall -std=c99 -march=armv6 -mthumb -mthumb-interwork -Os -I"$(CTRULIB)/include" -I$(DEVKITPRO)/libnds/include
-LDFLAGS += --script=ccd00.ld -L"$(DEVKITARM)/arm-none-eabi/lib" -L"$(CTRULIB)/lib" -Map=output.map
+CFLAGS += -Wall -std=c99 -march=armv6 -mthumb -mthumb-interwork -Os -ffunction-sections -I"$(CTRULIB)/include" -I$(DEVKITPRO)/libnds/include
+LDFLAGS += --script=ccd00.ld -L"$(DEVKITARM)/arm-none-eabi/lib" -L"$(CTRULIB)/lib" -Map=output.map --gc-sections
 
 CFILES = $(wildcard source/*.c)
 BINFILES = $(wildcard data/*.bin)

--- a/app_bootloader/ccd00.ld
+++ b/app_bootloader/ccd00.ld
@@ -1,4 +1,5 @@
 OUTPUT_ARCH(arm)
+ENTRY(_start)
 
 MEMORY
 {
@@ -11,6 +12,7 @@ SECTIONS
 	.text : ALIGN(0x100) {
 		build/crt0.o(.init)
 		*(.text)
+		*(.text.*)
 		*(.rodata)
 	}
 

--- a/app_code/Makefile
+++ b/app_code/Makefile
@@ -17,8 +17,8 @@ CC = arm-none-eabi-gcc
 LINK = arm-none-eabi-ld
 AS = arm-none-eabi-as
 OBJCOPY = arm-none-eabi-objcopy
-CFLAGS += -Wall -std=c99 -march=armv6 -mthumb -Os -fpie -I"$(CTRULIB)/include" -I$(DEVKITPRO)/libnds/include
-LDFLAGS += --script=ccd00.ld -L"$(DEVKITARM)/arm-none-eabi/lib" -L"$(CTRULIB)/lib" -Map=output.map
+CFLAGS += -Wall -std=c99 -march=armv6 -mthumb -Os -fpie -ffunction-sections -I"$(CTRULIB)/include" -I$(DEVKITPRO)/libnds/include
+LDFLAGS += --script=ccd00.ld -L"$(DEVKITARM)/arm-none-eabi/lib" -L"$(CTRULIB)/lib" -Map=output.map --gc-sections
 
 CFILES = $(wildcard source/*.c)
 BINFILES = $(wildcard data/*.bin)

--- a/app_code/ccd00.ld
+++ b/app_code/ccd00.ld
@@ -1,4 +1,5 @@
 OUTPUT_ARCH(arm)
+ENTRY(_start)
 
 MEMORY
 {
@@ -11,6 +12,7 @@ SECTIONS
 	.text : ALIGN(0x100) {
 		build/crt0.o(.init)
 		*(.text)
+		*(.text.*)
 		*(.rodata)
 		_got_start = .;
 		*(.got)

--- a/libctru-fpic/Makefile
+++ b/libctru-fpic/Makefile
@@ -4,7 +4,7 @@ endif
 
 include $(DEVKITARM)/base_rules
 
-CFLAGS += -Wall -std=c99 -march=armv6 -Os -fpic -I"$(CURDIR)/include/"
+CFLAGS += -Wall -std=c99 -march=armv6 -Os -fpic -ffunction-sections -I"$(CURDIR)/include/"
 
 CFILES = $(wildcard source/*.c)
 OFILES = $(CFILES:source/%.c=build/%.o)

--- a/libctru/Makefile
+++ b/libctru/Makefile
@@ -4,7 +4,7 @@ endif
 
 include $(DEVKITARM)/base_rules
 
-CFLAGS += -Wall -std=c99 -march=armv6 -Os -I"$(CURDIR)/include/"
+CFLAGS += -Wall -std=c99 -march=armv6 -Os -ffunction-sections -I"$(CURDIR)/include/"
 
 CFILES = $(wildcard source/*.c)
 OFILES = $(CFILES:source/%.c=build/%.o)


### PR DESCRIPTION
The current path handling code for opening the file handle to the 3dsx sucks because of these reasons:

- 3dslink paths are not supported (see smealum/3ds_hb_menu#45)
- Non-ASCII characters in paths are not supported.

This pull request solves both issues, and as a side effect I had to introduce some dead code elimination optimizations in order to fit the ropbin in 32KB.